### PR TITLE
Import traits

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -3,8 +3,12 @@
 namespace Orchestra\Testbench\BrowserKit;
 
 use Mockery;
+use Laravel\BrowserKitTesting\WithoutEvents;
 use Orchestra\Testbench\Traits\WithFactories;
+use Laravel\BrowserKitTesting\WithoutMiddleware;
 use Orchestra\Testbench\Traits\ApplicationTrait;
+use Laravel\BrowserKitTesting\DatabaseMigrations;
+use Laravel\BrowserKitTesting\DatabaseTransactions;
 use Laravel\BrowserKitTesting\Concerns\ImpersonatesUsers;
 use Laravel\BrowserKitTesting\Concerns\MakesHttpRequests;
 use Laravel\BrowserKitTesting\Concerns\InteractsWithConsole;


### PR DESCRIPTION
After updating to Laravel 5.4 and using this package for testing, we suddenly got a lot of 401 responsed and found out the WithoutMiddleware trait wasn't being called.
Seems the traits where not imported properly, and we had to update the `use` statements in our codebase.

So the only change in the PR is importing the following traits:

- `Laravel\BrowserKitTesting\WithoutEvents`
- `Laravel\BrowserKitTesting\WithoutMiddleware`
- `Laravel\BrowserKitTesting\DatabaseMigrations`
- `Laravel\BrowserKitTesting\DatabaseTransactions`